### PR TITLE
add carousel for tasks in homepage

### DIFF
--- a/index.html
+++ b/index.html
@@ -70,7 +70,7 @@
     <main class="mt-5">
       <div class="container-fluid">
         <div class="row justify-content-center">
-          <div class="col-12 col-lg-8">
+          <div class="col-12 col-md-8">
             <h1 class="text-center">Welcome to Group 1 Todo list Website</h1>
             <img
               class="w-100 mt-4 mb-5"
@@ -78,12 +78,71 @@
               alt="team work"
             />
             <div class="d-flex justify-content-around">
-              <a class="btn btn-success my-1 btn-lg" href="tasks.html"
+              <a class="btn btn-success my-1 btn-lg btn-xl" href="tasks.html"
                 >Go to Tasks</a
               >
               <a class="btn btn-primary my-1 btn-lg" href="create.html"
                 >Create New Task</a
               >
+            </div>
+
+            <div id="carousel_tasks" class="col-12 col-md-8 mt-4">
+              <div class="carousel slide" data-bs-ride="carousel" id="carouselExampleCaptions">
+                <div class="carousel-indicators">
+                  <button type="button" data-bs-target="#carouselExampleCaptions" data-bs-slide-to="0" class="active" aria-current="true" aria-label="Slide 1"></button>
+                  <button type="button" data-bs-target="#carouselExampleCaptions" data-bs-slide-to="1" aria-label="Slide 2"></button>
+                  <button type="button" data-bs-target="#carouselExampleCaptions" data-bs-slide-to="2" aria-label="Slide 3"></button>
+                  <button type="button" data-bs-target="#carouselExampleCaptions" data-bs-slide-to="3" aria-label="Slide 3"></button>
+                  <button type="button" data-bs-target="#carouselExampleCaptions" data-bs-slide-to="4" aria-label="Slide 3"></button>
+                  <button type="button" data-bs-target="#carouselExampleCaptions" data-bs-slide-to="5" aria-label="Slide 3"></button>
+                </div>
+                <div class="carousel-inner">
+                  <div class="carousel-item active">
+                    <img src="https://via.placeholder.com/400x200.png?text=Create A Wireframe" class="d-block w-100" alt="Create A Wireframe">
+                    <div class="carousel-caption d-none d-md-block">
+                      <h5>Create A Wireframe</h5>
+                    </div>
+                  </div>
+                  <div class="carousel-item">
+                    <img src="https://via.placeholder.com/400x200.png?text=Implement your wireframe" class="d-block w-100" alt="Implement your wireframe">
+                    <div class="carousel-caption d-none d-md-block">
+                      <h5>Implement your wireframe</h5>
+                    </div>
+                  </div>
+                  <div class="carousel-item">
+                    <img src="https://via.placeholder.com/400x200.png?text=Create a Task Card Layout" class="d-block w-100" alt="Create a Task Card Layout">
+                    <div class="carousel-caption d-none d-md-block">
+                      <h5>Create a Task Card Layout</h5>
+                    </div>
+                  </div>
+                  <div class="carousel-item">
+                    <img src="https://via.placeholder.com/400x200.png?text=Implement your Bootstrap" class="d-block w-100" alt="Implement your Bootstrap">
+                    <div class="carousel-caption d-none d-md-block">
+                      <h5>Implement your Bootstrap</h5>
+                    </div>
+                  </div>
+                  <div class="carousel-item">
+                    <img src="https://via.placeholder.com/400x200.png?text=Work Together on GitHub" class="d-block w-100" alt="Work Together on GitHub">
+                    <div class="carousel-caption d-none d-md-block">
+                      <h5>Work Together on GitHub</h5>
+                    </div>
+                  </div>
+                  <div class="carousel-item">
+                    <img src="https://via.placeholder.com/400x200.png?text=Evaluate Team Project" class="d-block w-100" alt="Evaluate Team Project">
+                    <div class="carousel-caption d-none d-md-block">
+                      <h5>Evaluate Team Project</h5>
+                    </div>
+                  </div>
+                </div>
+                <button class="carousel-control-prev" type="button" data-bs-target="#carouselExampleCaptions" data-bs-slide="prev">
+                  <span class="carousel-control-prev-icon" aria-hidden="true"></span>
+                  <span class="visually-hidden">Previous</span>
+                </button>
+                <button class="carousel-control-next" type="button" data-bs-target="#carouselExampleCaptions" data-bs-slide="next">
+                  <span class="carousel-control-next-icon" aria-hidden="true"></span>
+                  <span class="visually-hidden">Next</span>
+                </button>
+              </div>
             </div>
           </div>
         </div>

--- a/index.html
+++ b/index.html
@@ -85,64 +85,64 @@
                 >Create New Task</a
               >
             </div>
+          </div>
 
-            <div id="carousel_tasks" class="col-12 col-md-8 mt-4">
-              <div class="carousel slide" data-bs-ride="carousel" id="carouselExampleCaptions">
-                <div class="carousel-indicators">
-                  <button type="button" data-bs-target="#carouselExampleCaptions" data-bs-slide-to="0" class="active" aria-current="true" aria-label="Slide 1"></button>
-                  <button type="button" data-bs-target="#carouselExampleCaptions" data-bs-slide-to="1" aria-label="Slide 2"></button>
-                  <button type="button" data-bs-target="#carouselExampleCaptions" data-bs-slide-to="2" aria-label="Slide 3"></button>
-                  <button type="button" data-bs-target="#carouselExampleCaptions" data-bs-slide-to="3" aria-label="Slide 3"></button>
-                  <button type="button" data-bs-target="#carouselExampleCaptions" data-bs-slide-to="4" aria-label="Slide 3"></button>
-                  <button type="button" data-bs-target="#carouselExampleCaptions" data-bs-slide-to="5" aria-label="Slide 3"></button>
-                </div>
-                <div class="carousel-inner">
-                  <div class="carousel-item active">
-                    <img src="https://via.placeholder.com/400x200.png?text=Create A Wireframe" class="d-block w-100" alt="Create A Wireframe">
-                    <div class="carousel-caption d-none d-md-block">
-                      <h5>Create A Wireframe</h5>
-                    </div>
-                  </div>
-                  <div class="carousel-item">
-                    <img src="https://via.placeholder.com/400x200.png?text=Implement your wireframe" class="d-block w-100" alt="Implement your wireframe">
-                    <div class="carousel-caption d-none d-md-block">
-                      <h5>Implement your wireframe</h5>
-                    </div>
-                  </div>
-                  <div class="carousel-item">
-                    <img src="https://via.placeholder.com/400x200.png?text=Create a Task Card Layout" class="d-block w-100" alt="Create a Task Card Layout">
-                    <div class="carousel-caption d-none d-md-block">
-                      <h5>Create a Task Card Layout</h5>
-                    </div>
-                  </div>
-                  <div class="carousel-item">
-                    <img src="https://via.placeholder.com/400x200.png?text=Implement your Bootstrap" class="d-block w-100" alt="Implement your Bootstrap">
-                    <div class="carousel-caption d-none d-md-block">
-                      <h5>Implement your Bootstrap</h5>
-                    </div>
-                  </div>
-                  <div class="carousel-item">
-                    <img src="https://via.placeholder.com/400x200.png?text=Work Together on GitHub" class="d-block w-100" alt="Work Together on GitHub">
-                    <div class="carousel-caption d-none d-md-block">
-                      <h5>Work Together on GitHub</h5>
-                    </div>
-                  </div>
-                  <div class="carousel-item">
-                    <img src="https://via.placeholder.com/400x200.png?text=Evaluate Team Project" class="d-block w-100" alt="Evaluate Team Project">
-                    <div class="carousel-caption d-none d-md-block">
-                      <h5>Evaluate Team Project</h5>
-                    </div>
-                  </div>
-                </div>
-                <button class="carousel-control-prev" type="button" data-bs-target="#carouselExampleCaptions" data-bs-slide="prev">
-                  <span class="carousel-control-prev-icon" aria-hidden="true"></span>
-                  <span class="visually-hidden">Previous</span>
-                </button>
-                <button class="carousel-control-next" type="button" data-bs-target="#carouselExampleCaptions" data-bs-slide="next">
-                  <span class="carousel-control-next-icon" aria-hidden="true"></span>
-                  <span class="visually-hidden">Next</span>
-                </button>
+          <div id="carousel_tasks" class="col-12 col-md-8 mt-4">
+            <div class="carousel slide" data-bs-ride="carousel" id="carouselExampleCaptions">
+              <div class="carousel-indicators">
+                <button type="button" data-bs-target="#carouselExampleCaptions" data-bs-slide-to="0" class="active" aria-current="true" aria-label="Slide 1"></button>
+                <button type="button" data-bs-target="#carouselExampleCaptions" data-bs-slide-to="1" aria-label="Slide 2"></button>
+                <button type="button" data-bs-target="#carouselExampleCaptions" data-bs-slide-to="2" aria-label="Slide 3"></button>
+                <button type="button" data-bs-target="#carouselExampleCaptions" data-bs-slide-to="3" aria-label="Slide 3"></button>
+                <button type="button" data-bs-target="#carouselExampleCaptions" data-bs-slide-to="4" aria-label="Slide 3"></button>
+                <button type="button" data-bs-target="#carouselExampleCaptions" data-bs-slide-to="5" aria-label="Slide 3"></button>
               </div>
+              <div class="carousel-inner">
+                <div class="carousel-item active">
+                  <img src="https://via.placeholder.com/400x200.png?text=Create A Wireframe" class="d-block w-100" alt="Create A Wireframe">
+                  <div class="carousel-caption d-none d-md-block">
+                    <h5>Create A Wireframe</h5>
+                  </div>
+                </div>
+                <div class="carousel-item">
+                  <img src="https://via.placeholder.com/400x200.png?text=Implement your wireframe" class="d-block w-100" alt="Implement your wireframe">
+                  <div class="carousel-caption d-none d-md-block">
+                    <h5>Implement your wireframe</h5>
+                  </div>
+                </div>
+                <div class="carousel-item">
+                  <img src="https://via.placeholder.com/400x200.png?text=Create a Task Card Layout" class="d-block w-100" alt="Create a Task Card Layout">
+                  <div class="carousel-caption d-none d-md-block">
+                    <h5>Create a Task Card Layout</h5>
+                  </div>
+                </div>
+                <div class="carousel-item">
+                  <img src="https://via.placeholder.com/400x200.png?text=Implement your Bootstrap" class="d-block w-100" alt="Implement your Bootstrap">
+                  <div class="carousel-caption d-none d-md-block">
+                    <h5>Implement your Bootstrap</h5>
+                  </div>
+                </div>
+                <div class="carousel-item">
+                  <img src="https://via.placeholder.com/400x200.png?text=Work Together on GitHub" class="d-block w-100" alt="Work Together on GitHub">
+                  <div class="carousel-caption d-none d-md-block">
+                    <h5>Work Together on GitHub</h5>
+                  </div>
+                </div>
+                <div class="carousel-item">
+                  <img src="https://via.placeholder.com/400x200.png?text=Evaluate Team Project" class="d-block w-100" alt="Evaluate Team Project">
+                  <div class="carousel-caption d-none d-md-block">
+                    <h5>Evaluate Team Project</h5>
+                  </div>
+                </div>
+              </div>
+              <button class="carousel-control-prev" type="button" data-bs-target="#carouselExampleCaptions" data-bs-slide="prev">
+                <span class="carousel-control-prev-icon" aria-hidden="true"></span>
+                <span class="visually-hidden">Previous</span>
+              </button>
+              <button class="carousel-control-next" type="button" data-bs-target="#carouselExampleCaptions" data-bs-slide="next">
+                <span class="carousel-control-next-icon" aria-hidden="true"></span>
+                <span class="visually-hidden">Next</span>
+              </button>
             </div>
           </div>
         </div>


### PR DESCRIPTION
I think doing one with many slides at the same time (like the Wireframe) is beyond my level of expertise. 

It took me long but I followed Bootstrap Carousel (https://getbootstrap.com/docs/5.0/components/carousel/#how-it-works). It shows one slide at once, instead of many. I think this is good enough for our goal.

See the demo in https://andreaisla.github.io/task-planner/